### PR TITLE
Load builtin backends dynamically

### DIFF
--- a/internal/catalog/templates/besu.star
+++ b/internal/catalog/templates/besu.star
@@ -1,5 +1,7 @@
 version = "0.0.1"
 
+name = "besu"
+
 chains = ["mainnet", "goerli", "sepolia"]
 
 config = {

--- a/internal/catalog/templates/geth.star
+++ b/internal/catalog/templates/geth.star
@@ -1,5 +1,7 @@
 version = "0.0.1"
 
+name = "geth"
+
 chains = ["mainnet", "goerli", "sepolia"]
 
 config = {

--- a/internal/catalog/templates/lighthouse.star
+++ b/internal/catalog/templates/lighthouse.star
@@ -1,5 +1,7 @@
 version = "0.0.1"
 
+name = "lighthouse"
+
 chains = ["mainnet", "goerli", "sepolia"]
 
 config = {

--- a/internal/catalog/templates/nethermind.star
+++ b/internal/catalog/templates/nethermind.star
@@ -1,5 +1,7 @@
 version = "0.0.1"
 
+name = "nethermind"
+
 chains = ["mainnet", "goerli", "sepolia"]
 
 config = {

--- a/internal/catalog/templates/prysm.star
+++ b/internal/catalog/templates/prysm.star
@@ -1,5 +1,7 @@
 version = "0.0.1"
 
+name = "prysm"
+
 chains = ["mainnet"]
 
 config = {

--- a/internal/catalog/templates/teku.star
+++ b/internal/catalog/templates/teku.star
@@ -1,5 +1,7 @@
 version = "0.0.1"
 
+name = "teku"
+
 chains = ["mainnet", "goerli", "sepolia"]
 
 config = {


### PR DESCRIPTION
This PR loads the builtin backend plugins directly from the embed folder instead of manually loading each file. This is an iterative approach to have multiple catalogs and downloading catalogs from external resources.