### PR TITLE
Load catalog from cli flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ BUG FIXES:
 
 IMPROVEMENTS:
 
+- catalog: Add `--catalog` flag to server to load an external catalog [[GH-75](https://github.com/umbracle/eth2-validator/issues/75)]
 - core: Add sync tracker with babel [[GH-41](https://github.com/umbracle/eth2-validator/issues/41)]
 - catalog: Add logging field in catalog [[GH-62](https://github.com/umbracle/eth2-validator/issues/62)]
 - core: Add an alias for the deployment [[GH-23](https://github.com/umbracle/eth2-validator/issues/23)]

--- a/internal/cmd/server.go
+++ b/internal/cmd/server.go
@@ -23,6 +23,7 @@ type ServerCommand struct {
 
 	logLevel string
 	volume   string
+	catalog  []string
 }
 
 // Help implements the cli.Command interface
@@ -42,6 +43,7 @@ func (c *ServerCommand) Run(args []string) int {
 	flags := flag.NewFlagSet("server", flag.ContinueOnError)
 	flags.StringVar(&c.logLevel, "log-level", "info", "")
 	flags.StringVar(&c.volume, "volume", "", "")
+	flags.StringSliceVar(&c.catalog, "catalog", []string{}, "")
 
 	if err := flags.Parse(args); err != nil {
 		c.UI.Error(err.Error())
@@ -60,6 +62,7 @@ func (c *ServerCommand) Run(args []string) int {
 	}
 
 	sCfg := server.DefaultConfig()
+	sCfg.Catalog = c.catalog
 	sCfg.PersistentDB = db
 
 	srv, err := server.NewServer(logger, sCfg)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -20,6 +20,7 @@ import (
 type Config struct {
 	GrpcAddr     string
 	PersistentDB *bolt.DB
+	Catalog      []string
 }
 
 // DefaultConfig returns a default configuration
@@ -63,6 +64,15 @@ func NewServer(logger hclog.Logger, config *Config) (*Server, error) {
 	catalog, err := catalog.NewCatalog()
 	if err != nil {
 		return nil, err
+	}
+
+	catalog.SetLogger(logger)
+
+	// load the custom catalogs
+	for _, ctg := range config.Catalog {
+		if err := catalog.Load(ctg); err != nil {
+			return nil, fmt.Errorf("failed to load catalog '%s': %v", ctg, err)
+		}
 	}
 
 	srv := &Server{


### PR DESCRIPTION
This PR adds a new flag to `server` command to load an extra catalog different from the builtin one.